### PR TITLE
Handle error when invalid field is requested

### DIFF
--- a/.changeset/modern-peas-serve.md
+++ b/.changeset/modern-peas-serve.md
@@ -1,0 +1,5 @@
+---
+'@graphql-authz/core': patch
+---
+
+return undefined when a field that does exist is requested

--- a/__tests__/post-exec-rules/query.test.ts
+++ b/__tests__/post-exec-rules/query.test.ts
@@ -76,6 +76,15 @@ const userQuery = `
   }
 `;
 
+const invalidQuery = `
+  query getUser {
+    user {
+      id
+      NOTINSCHEMA
+    }
+  }
+`;
+
 const authSchema = {
   Query: {
     post: { __authz: { rules: ['FailingPostExecRule'] } },
@@ -211,6 +220,18 @@ describe.each(['apollo-plugin', 'envelop-plugin'] as const)(
                 expect(error).toBeUndefined();
                 expect(result?.errors).toBeUndefined();
                 expect(result?.data).toBeDefined();
+              });
+
+              it('should allow a validation error when given and invalid query', async () => {
+                const result = await server.executeOperation({
+                  query: invalidQuery
+                });
+
+                expect(result.errors).toHaveLength(1);
+                expect(result.errors?.[0].extensions?.code).toEqual(
+                  'GRAPHQL_VALIDATION_FAILED'
+                );
+                expect(result.data).toBeUndefined();
               });
             });
           });

--- a/__tests__/pre-exec-rules/query.test.ts
+++ b/__tests__/pre-exec-rules/query.test.ts
@@ -58,6 +58,15 @@ const userQuery = `
   }
 `;
 
+const invalidQuery = `
+  query getUser {
+    user {
+      id
+      NOTINSCHEMA
+    }
+  }
+`;
+
 const authSchema = {
   Query: {
     post: { __authz: { rules: ['FailingPreExecRule'] } },
@@ -139,6 +148,18 @@ describe.each(['apollo-plugin', 'envelop-plugin'] as const)(
 
                 expect(result.errors).toBeUndefined();
                 expect(result.data).toBeDefined();
+              });
+
+              it('should allow a validation error when given and invalid query', async () => {
+                const result = await server.executeOperation({
+                  query: invalidQuery
+                });
+
+                expect(result.errors).toHaveLength(1);
+                expect(result.errors?.[0].extensions?.code).toEqual(
+                  'GRAPHQL_VALIDATION_FAILED'
+                );
+                expect(result.data).toBeUndefined();
               });
             });
           });

--- a/packages/core/src/rules-compiler.ts
+++ b/packages/core/src/rules-compiler.ts
@@ -287,6 +287,11 @@ export function compileRules({
         const parentTypeName = parentType.name;
         const graphqlField = parentType.getFields()[node.name.value];
 
+        // this will occur if we are passed a field not in our schema
+        if (graphqlField === undefined){
+          return undefined
+        }
+
         const fieldArgs = getArgumentValues(graphqlField, node, variables);
 
         const extensionsConfigs = getConfigsByExtensions(

--- a/packages/core/src/rules-compiler.ts
+++ b/packages/core/src/rules-compiler.ts
@@ -288,7 +288,7 @@ export function compileRules({
         const graphqlField = parentType.getFields()[node.name.value];
 
         // this will occur if we are passed a field not in our schema
-        if (graphqlField === undefined){
+        if (graphqlField === undefined) {
           return undefined;
         }
 

--- a/packages/core/src/rules-compiler.ts
+++ b/packages/core/src/rules-compiler.ts
@@ -289,7 +289,7 @@ export function compileRules({
 
         // this will occur if we are passed a field not in our schema
         if (graphqlField === undefined){
-          return undefined
+          return undefined;
         }
 
         const fieldArgs = getArgumentValues(graphqlField, node, variables);


### PR DESCRIPTION
Currently if a query is passed to the rules library that references a field that does not exist on schema the call to `getFields` will return undefined and that will cause the next call to `getArgumentValues` to throw the following `TypeError`:
```
Cannot read properties of undefined (reading 'args')
TypeError: Cannot read properties of undefined (reading 'args')
    at getArgumentValues (/Users/jeffreydefond/projects/graphql-authz/node_modules/graphql/execution/values.js:183:28)
    at Object.Field (/Users/jeffreydefond/projects/graphql-authz/packages/core/src/rules-compiler.ts:290:27)
    at Object.enter (/Users/jeffreydefond/projects/graphql-authz/node_modules/graphql/utilities/TypeInfo.js:387:27)
    at visit (/Users/jeffreydefond/projects/graphql-authz/node_modules/graphql/language/visitor.js:200:21)
    at compileRules (/Users/jeffreydefond/projects/graphql-authz/packages/core/src/rules-compiler.ts:346:3)
    at Object.requestDidStart (/Users/jeffreydefond/projects/graphql-authz/packages/plugins/apollo-server/src/index.ts:26:29)
    at initializeRequestListenerDispatcher (/Users/jeffreydefond/projects/graphql-authz/node_modules/apollo-server-express/node_modules/apollo-server-core/src/requestPipeline.ts:598:39)
    at processGraphQLRequest (/Users/jeffreydefond/projects/graphql-authz/node_modules/apollo-server-express/node_modules/apollo-server-core/src/requestPipeline.ts:115:28)
    at ApolloServer.executeOperation (/Users/jeffreydefond/projects/graphql-authz/node_modules/apollo-server-express/node_modules/apollo-server-core/src/ApolloServer.ts:995:33)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```
This PR adds tests to replicate this error, and updates `visitWithTypeInfo` to return undefined when we find that `getFields` on the partentType has returned undefined. 

Related Issue: https://github.com/AstrumU/graphql-authz/issues/76