### PR TITLE
fix: no deep import of dependencies from graphql

### DIFF
--- a/packages/core/src/rules-compiler.ts
+++ b/packages/core/src/rules-compiler.ts
@@ -9,9 +9,9 @@ import {
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLField,
-  isIntrospectionType
+  isIntrospectionType,
+  getArgumentValues
 } from 'graphql';
-import { getArgumentValues } from 'graphql/execution/values';
 
 import {
   getDeepType,


### PR DESCRIPTION
The deep import of `getArgumentValues` from the `graphql` package causes trouble when using this library in an esm/esbuild based project, because esbuild pulls in the complete package a second time. The `graphql` package will detect this at runtime and will throw an error.

