### PR TITLE
Fix preExecutionRules with @apollo/server V4

### DIFF
--- a/.changeset/hungry-drinks-raise.md
+++ b/.changeset/hungry-drinks-raise.md
@@ -1,0 +1,5 @@
+---
+'@graphql-authz/apollo-server-plugin': patch
+---
+
+Shouldn't affect anything except make the plugin work for @apollo/server v4

--- a/packages/plugins/apollo-server/src/index.ts
+++ b/packages/plugins/apollo-server/src/index.ts
@@ -46,7 +46,7 @@ export function authZApolloPlugin(config: IAuthZConfig): ApolloServerPlugin {
           try {
             await Promise.all(
               compiledRules.preExecutionRules.map(rule =>
-                rule.execute(requestContext.context, rule.config.fieldArgs)
+                rule.execute(requestContext.context || requestContext.contextValue, rule.config.fieldArgs)
               )
             );
           } catch (error) {


### PR DESCRIPTION
If using @apollo/server v4 the context value in rule execution is undefined.

This is because: "The context field has been renamed contextValue for consistency with the graphql-js API and to help differentiate from the context option of integration functions (the function which returns a context value)." as seen in https://www.apollographql.com/docs/apollo-server/migration/#fields-on-graphqlrequestcontext

To fix this, I have added "|| requestContext.contextValue" into the preExecutionRules execution code. Shouldn't affect anything else, but it makes this aspect of the plugin compatible.

Note: I am not going to touch the postExecRules since that dives into the @graphql-authz/core package... and I don't use that feature anyway.

Would be super grateful if this could be merged ASAP so I can continue using @graphql-authz/apollo-server-plugin... I imagine the apollo update might have other issues, but this is a quick fix to get the main functionality working again.