### PR TITLE
chore: bump `@envelop/core` from 1.0.3 to 5.0.1

### DIFF
--- a/.changeset/five-adults-drop.md
+++ b/.changeset/five-adults-drop.md
@@ -1,0 +1,8 @@
+---
+'@graphql-authz/envelop-plugin': patch
+---
+
+Bump @envelop/core from 1.0.3 to 5.0.1
+Bump @envelop/types from 1.4.0 to 5.0.0
+
+BREAKING CHANGE: Typescript support of @envelop/types < 3.0.0 is dropped. Please update your "@envelop" version or ignore type violations. Plugin is still compatible with @envelop/core < 3.0.0 except of types.

--- a/__tests__/mock-server.ts
+++ b/__tests__/mock-server.ts
@@ -1,10 +1,11 @@
+import * as GraphQLJS from 'graphql';
 import {
   IExecutableSchemaDefinition,
   makeExecutableSchema
 } from '@graphql-tools/schema';
 import { addMocksToSchema, IMocks } from '@graphql-tools/mock';
 import { wrapSchema } from '@graphql-tools/wrap';
-import { envelop, useSchema } from '@envelop/core';
+import { envelop, useSchema, useEngine } from '@envelop/core';
 import { ApolloServer } from '@apollo/server';
 import { GraphQLSchema } from 'graphql';
 
@@ -113,14 +114,17 @@ function mockServerWithEnvelopPlugin(
   });
 
   const getEnveloped = envelop({
-    plugins: [useSchema(schemaWithMocks), authZEnvelopPlugin(pluginConfig)]
+    plugins: [
+      useEngine(GraphQLJS),
+      useSchema(schemaWithMocks),
+      authZEnvelopPlugin(pluginConfig)
+    ]
   });
 
   const { schema: envelopedSchema, execute, contextFactory } = getEnveloped();
 
   const wrappedSchema = wrapSchema({
     schema: envelopedSchema,
-    // @ts-expect-error
     executor: async requestContext =>
       execute({
         schema: envelopedSchema,

--- a/examples/packages/envelop/package.json
+++ b/examples/packages/envelop/package.json
@@ -18,7 +18,7 @@
     "access": "restricted"
   },
   "dependencies": {
-    "@envelop/core": "1.5.0"
+    "@envelop/core": "5.0.1"
   },
   "devDependencies": {
     "typescript": "4.9.3"

--- a/examples/packages/envelop/src/index.ts
+++ b/examples/packages/envelop/src/index.ts
@@ -1,4 +1,5 @@
 import { createServer } from 'http';
+import { GraphQLError } from 'graphql'
 import { envelop, useExtendContext, useSchema, useTiming } from '@envelop/core';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import {
@@ -168,8 +169,8 @@ const getEnveloped = envelop({
     useSchema(schema),
     useTiming(),
     // authenticator
-    useExtendContext(req => ({
-      user: users.find(({ id }) => id === req.headers['x-user-id']) || null
+    useExtendContext(context => ({
+      user: users.find(({ id }) => id === context.req.headers['x-user-id']) || null
     })),
     // graphql-authz plugin
     authZEnvelopPlugin({ rules: authZRules })
@@ -216,11 +217,14 @@ const server = createServer((req, res) => {
 
         res.end(JSON.stringify(result));
       } catch (error) {
-        res.end(
-          JSON.stringify({
-            errors: [error]
-          })
-        );
+        if (error instanceof GraphQLError) {
+          res.end(JSON.stringify({ error }));
+          return;
+        }
+
+        const errorMessage = error instanceof Error ? error.message : "Unknown unexpected error!"
+        res.statusCode = 500;
+        res.end(JSON.stringify({ error: errorMessage }));
       }
     })();
   });

--- a/examples/packages/envelop/src/index.ts
+++ b/examples/packages/envelop/src/index.ts
@@ -1,7 +1,9 @@
 import { createServer } from 'http';
+import * as GraphQLJS from 'graphql'
 import { GraphQLError } from 'graphql'
-import { envelop, useExtendContext, useSchema, useTiming } from '@envelop/core';
+import { envelop, useExtendContext, useSchema, useEngine } from '@envelop/core';
 import { makeExecutableSchema } from '@graphql-tools/schema';
+
 import {
   preExecRule,
   postExecRule,
@@ -166,8 +168,8 @@ const schema = authZDirectiveTransformer(
 
 const getEnveloped = envelop({
   plugins: [
+    useEngine(GraphQLJS),
     useSchema(schema),
-    useTiming(),
     // authenticator
     useExtendContext(context => ({
       user: users.find(({ id }) => id === context.req.headers['x-user-id']) || null

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -235,17 +235,20 @@
   dependencies:
     xss "^1.0.8"
 
-"@envelop/core@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@envelop/core/-/core-1.5.0.tgz#047392e24ec3ce2a009e62ad86ee7e8e6c8238e9"
-  integrity sha512-hAQj40tfuVD4nOPpKFjWvdzf28CyJlzY26Z/whXGVgrjD6LK9foh/rQzIALg8cSae4xDCT34j1c11E5Mhw6VHw==
+"@envelop/core@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@envelop/core/-/core-5.0.1.tgz#7993c5d577b1de01645539cbbe3eab26f213a35a"
+  integrity sha512-wxA8EyE1fPnlbP0nC/SFI7uU8wSNf4YjxZhAPu0P63QbgIvqHtHsH4L3/u+rsTruzhk3OvNRgQyLsMfaR9uzAQ==
   dependencies:
-    "@envelop/types" "1.4.0"
+    "@envelop/types" "5.0.0"
+    tslib "^2.5.0"
 
-"@envelop/types@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@envelop/types/-/types-1.4.0.tgz#35327e9d23968434dd0a049ec464f1645729f886"
-  integrity sha512-ScEvh7ORsUfiML18rQflN/gI17v0f0QbgpSa3F51T6Ix0QB/TpFC+s/uq+JNbeFH0c2j7vSCc70IFxEOv8M3SQ==
+"@envelop/types@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@envelop/types/-/types-5.0.0.tgz#3ae59b50ec31d4bdcc7bd0b47e9c8cf2ac44b0ff"
+  integrity sha512-IPjmgSc4KpQRlO4qbEDnBEixvtb06WDmjKfi/7fkZaryh5HuOmTtixe1EupQI5XfXO8joc3d27uUZ0QdC++euA==
+  dependencies:
+    tslib "^2.5.0"
 
 "@graphql-tools/batch-delegate@^9.0.0":
   version "9.0.0"
@@ -1697,10 +1700,10 @@ graphql-ws@5.14.0:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.14.0.tgz#766f249f3974fc2c48fae0d1fb20c2c4c79cd591"
   integrity sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==
 
-graphql@16.0.1:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.0.1.tgz#93a13cd4e0e38ca8d0832e79614c8578bfd34f10"
-  integrity sha512-oPvCuu6dlLdiz8gZupJ47o1clgb72r1u8NDBcQYjcV6G/iEdmE11B1bBlkhXRvV0LisP/SXRFP7tT6AgaTjpzg==
+graphql@16.8.1:
+  version "16.8.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
+  integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==
 
 has-bigints@^1.0.1:
   version "1.0.1"
@@ -2953,8 +2956,16 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3004,8 +3015,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@apollo/server": "4.7.5",
     "@changesets/cli": "^2.16.0",
-    "@envelop/types": "^1.4.0",
+    "@envelop/types": "^5.0.0",
     "@graphql-tools/mock": "^9.0.0",
     "@graphql-tools/schema": "^10.0.2",
     "@graphql-tools/wrap": "^10.0.1",

--- a/packages/plugins/envelop/package.json
+++ b/packages/plugins/envelop/package.json
@@ -30,9 +30,9 @@
     "@graphql-authz/core": "1.3.1"
   },
   "devDependencies": {
-    "@envelop/core": "1.5.0"
+    "@envelop/core": "5.0.1"
   },
   "peerDependencies": {
-    "@envelop/core": "^1.0.3"
+    "@envelop/core": "^5.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -907,17 +907,20 @@
     human-id "^1.0.2"
     prettier "^1.19.1"
 
-"@envelop/core@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@envelop/core/-/core-1.5.0.tgz#047392e24ec3ce2a009e62ad86ee7e8e6c8238e9"
-  integrity sha512-hAQj40tfuVD4nOPpKFjWvdzf28CyJlzY26Z/whXGVgrjD6LK9foh/rQzIALg8cSae4xDCT34j1c11E5Mhw6VHw==
+"@envelop/core@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@envelop/core/-/core-5.0.1.tgz#7993c5d577b1de01645539cbbe3eab26f213a35a"
+  integrity sha512-wxA8EyE1fPnlbP0nC/SFI7uU8wSNf4YjxZhAPu0P63QbgIvqHtHsH4L3/u+rsTruzhk3OvNRgQyLsMfaR9uzAQ==
   dependencies:
-    "@envelop/types" "1.4.0"
+    "@envelop/types" "5.0.0"
+    tslib "^2.5.0"
 
-"@envelop/types@1.4.0", "@envelop/types@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@envelop/types/-/types-1.4.0.tgz#35327e9d23968434dd0a049ec464f1645729f886"
-  integrity sha512-ScEvh7ORsUfiML18rQflN/gI17v0f0QbgpSa3F51T6Ix0QB/TpFC+s/uq+JNbeFH0c2j7vSCc70IFxEOv8M3SQ==
+"@envelop/types@5.0.0", "@envelop/types@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@envelop/types/-/types-5.0.0.tgz#3ae59b50ec31d4bdcc7bd0b47e9c8cf2ac44b0ff"
+  integrity sha512-IPjmgSc4KpQRlO4qbEDnBEixvtb06WDmjKfi/7fkZaryh5HuOmTtixe1EupQI5XfXO8joc3d27uUZ0QdC++euA==
+  dependencies:
+    tslib "^2.5.0"
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
Resolution for issue: https://github.com/AstrumU/graphql-authz/issues/118

Changes:
- Bump "@envelop/core" package from 1.0.3 to 5.0.1.
- Bump "@envelop/types" package from 1.4.0 to 5.0.0.
- Adjust the envelop sandbox and tests to work with the new version.
- Also repair envelop sandbox in general. As it was failing to read request headers.