### PR TITLE
chore: move `@graphql-authz/core` to plugins peerDependencies

### DIFF
--- a/.changeset/six-mayflies-march.md
+++ b/.changeset/six-mayflies-march.md
@@ -1,0 +1,8 @@
+---
+'@graphql-authz/directive': patch
+'@graphql-authz/apollo-server-plugin': patch
+'@graphql-authz/apollo-server-v2-plugin': patch
+'@graphql-authz/envelop-plugin': patch
+---
+
+move @graphql-authz/core to peerDependencies

--- a/packages/directive/package.json
+++ b/packages/directive/package.json
@@ -28,13 +28,13 @@
     "envelop"
   ],
   "dependencies": {
-    "@graphql-authz/core": "1.3.1",
     "@graphql-tools/utils": "10.0.11"
   },
   "devDependencies": {
     "graphql": "^16.0.0"
   },
   "peerDependencies": {
+    "@graphql-authz/core": "^1.3.1",
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
   }
 }

--- a/packages/plugins/apollo-server-v2/package.json
+++ b/packages/plugins/apollo-server-v2/package.json
@@ -26,14 +26,12 @@
     "authz",
     "apollo"
   ],
-  "dependencies": {
-    "@graphql-authz/core": "1.3.1"
-  },
   "devDependencies": {
     "apollo-server": "2.25.2",
     "apollo-server-plugin-base": "0.13.0"
   },
   "peerDependencies": {
+    "@graphql-authz/core": "^1.3.1",
     "apollo-server": "^2.25.2",
     "graphql": "^14.0.0 || ^15.0.0"
   }

--- a/packages/plugins/apollo-server/package.json
+++ b/packages/plugins/apollo-server/package.json
@@ -26,14 +26,12 @@
     "authz",
     "apollo"
   ],
-  "dependencies": {
-    "@graphql-authz/core": "1.3.1"
-  },
   "devDependencies": {
     "@apollo/server": "4.7.5"
   },
   "peerDependencies": {
     "@apollo/server": "^4.0.0",
+    "@graphql-authz/core": "^1.3.1",
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
   }
 }

--- a/packages/plugins/envelop/package.json
+++ b/packages/plugins/envelop/package.json
@@ -26,13 +26,11 @@
     "authz",
     "envelop"
   ],
-  "dependencies": {
-    "@graphql-authz/core": "1.3.1"
-  },
   "devDependencies": {
     "@envelop/core": "5.0.1"
   },
   "peerDependencies": {
-    "@envelop/core": "^5.0.1"
+    "@envelop/core": "^5.0.1",
+    "@graphql-authz/core": "^1.3.1"
   }
 }


### PR DESCRIPTION
Resolution for issue: https://github.com/AstrumU/graphql-authz/issues/83

**Root issues are**:
1. `@graphql-authz/core` is not written in a way to be version agnostic for its inputs. For instance, the reported issue happens due to `instanceof` usage.
2. All `authz` plugins are using `@graphql-authz/core` as an internal package dependency. As a result, the client might end up with 2 versions of `@graphql-authz/core` in node_modules.

**Solutions**:
1. We could refactor the library to avoid any version-incompatible code practices (class prototype usage, stateful functions, and classes). It is a nice practice, which guarantees library correctness even when a client or publisher screw-up with dependency management. But requires to allocate some time on it. (**Dropped**)
2. Fix plugin dependency management by moving `@graphql-authz/core` to peerDependencies. [See this StackOverflow discussion about peerDependencies](https://stackoverflow.com/a/34645112). (**Implemented**)